### PR TITLE
Remove AWK dependency

### DIFF
--- a/bashttpd.sh
+++ b/bashttpd.sh
@@ -23,7 +23,7 @@ Server: Slash Bin Slash Bash"
 
 function get_content_type() {
     URL_PATH=$1
-    CONTENT_TYPE=$( file --mime-type ${URL_PATH} | awk '{ print $2 }' )
+    CONTENT_TYPE=$( file -b --mime-type ${URL_PATH} )
 }
 
 function get_content_body() {
@@ -51,7 +51,7 @@ while read line; do
     # Look for a GET request
     echo ${line} | grep ^GET > /dev/null
     if [ $? -eq 0 ]; then
-        URL_PATH="${DOCROOT}$( echo ${line} | awk '{print $2}' )"
+        URL_PATH="${DOCROOT}$( echo ${line} | cut -d' ' -f2 )"
         URL_PATH=$( echo ${URL_PATH} | tr -d '\r' )
     fi
 done


### PR DESCRIPTION
The two uses of AWK in this script could be replaced by the faster
cut command, but the first one is unnecessary altogether... it can
be replaced with the "-b" (brief) switch to the "file" command.  The
result should be faster, and may run on more systems.
